### PR TITLE
Fix adding to an existing deposit

### DIFF
--- a/news/7.bugfix
+++ b/news/7.bugfix
@@ -1,0 +1,4 @@
+Fixed a bug where the existing deposit thickness was being zeroed-out before
+the plume was run. The plume now adds sediment to an existing deposit and
+leaves it up to the user to clear an existing deposit.
+

--- a/news/7.misc
+++ b/news/7.misc
@@ -1,0 +1,3 @@
+Removed ocean and river time series from the plume command line interface.
+The plume command now runs just a single plume.
+

--- a/plume/cli.py
+++ b/plume/cli.py
@@ -91,7 +91,7 @@ def load_config(file: Optional[TextIO] = None):
             "xy_of_lower_left": [0.0, 0.0],
         },
         "river": {
-            "filepath": "river.csv",
+            # "filepath": "river.csv",
             "width": 50.0,
             "depth": 5.0,
             "velocity": 1.5,
@@ -100,7 +100,7 @@ def load_config(file: Optional[TextIO] = None):
         },
         "sediment": {"removal_rate": 60.0, "bulk_density": 1600.0},
         "ocean": {
-            "filepath": "ocean.csv",
+            # "filepath": "ocean.csv",
             "along_shore_velocity": 0.1,
             "sediment_concentration": 0.0,
         },
@@ -134,24 +134,24 @@ def _contents_of_input_file(infile: str) -> str:
 
     contents = {
         "plume.toml": tomllib.dumps(dict(plume=params)),
-        "river.csv": as_csv(
-            [[0.0, 50.0, 5.0, 1.5]],
-            header=os.linesep.join(
-                [
-                    f"version: {__version__}",
-                    "Time [d], Width [m], Depth [m], Velocity [m/s]",
-                ]
-            ),
-        ),
-        "ocean.csv": as_csv(
-            [[0.0, 0.1, 0.0]],
-            header=os.linesep.join(
-                [
-                    f"version: {__version__}",
-                    "Time [d], Along-shore velocity [m/s], Sediment Concentration [-]",
-                ]
-            ),
-        ),
+        # "river.csv": as_csv(
+        #     [[0.0, 50.0, 5.0, 1.5]],
+        #     header=os.linesep.join(
+        #         [
+        #             f"version: {__version__}",
+        #             "Time [d], Width [m], Depth [m], Velocity [m/s]",
+        #         ]
+        #     ),
+        # ),
+        # "ocean.csv": as_csv(
+        #     [[0.0, 0.1, 0.0]],
+        #     header=os.linesep.join(
+        #         [
+        #             f"version: {__version__}",
+        #             "Time [d], Along-shore velocity [m/s], Sediment Concentration [-]",
+        #         ]
+        #     ),
+        # ),
     }
 
     return contents[infile]
@@ -310,7 +310,7 @@ def run(ctx, dry_run: bool) -> None:
         output_file = pathlib.Path(params["output"]["filepath"])
         if output_file.exists():
             err(f"{output_file}: output files exists")
-            click.Abort()
+            raise click.Abort()
 
         grid = RasterModelGrid(
             params["grid"]["shape"],
@@ -318,46 +318,36 @@ def run(ctx, dry_run: bool) -> None:
             xy_of_lower_left=params["grid"]["xy_of_lower_left"],
         )
 
-        deposit = grid.add_zeros("sediment_deposit_thickenss", at="node").reshape(
-            grid.shape
-        )
+        grid.add_zeros("sediment_deposit_thickenss", at="node")  # .reshape(grid.shape)
         grid.at_grid["sediment__removal_rate"] = params["sediment"]["removal_rate"]
         grid.at_grid["sediment__bulk_density"] = params["sediment"]["bulk_density"]
 
-        river = RiverTimeSeries(params["river"]["filepath"])
-        ocean = OceanTimeSeries(params["ocean"]["filepath"])
+        # river = RiverTimeSeries(params["river"]["filepath"])
+        # ocean = OceanTimeSeries(params["ocean"]["filepath"])
 
         params["river"]["angle"] = np.deg2rad(params["river"]["angle"])
 
-        n_days = 2
-        for day in range(n_days):
+        # n_days = 2
+        # for day in range(n_days):
 
-            grid = RasterModelGrid((500, 500), xy_spacing=(100.0, 100.0))
-            plume = Plume(
-                grid,
-                river_width=river.width,
-                river_depth=river.depth,
-                river_velocity=river.velocity,
-                river_angle=params["river"]["angle"],
-                river_loc=params["river"]["location"],
-                ocean_velocity=ocean.velocity,
-            )
-            plume.run_one_step()
+        plume = Plume(
+            grid,
+            river_width=params["river"]["width"],
+            river_depth=params["river"]["depth"],
+            river_velocity=params["river"]["velocity"],
+            river_angle=params["river"]["angle"],
+            river_loc=params["river"]["location"],
+            ocean_velocity=params["ocean"]["along_shore_velocity"],
+        )
+        plume.run_one_step()
 
-            deposit[:] += plume.calc_deposit_thickness(
-                params["sediment"]["removal_rate"]
-            )
-
-            river.update()
-            ocean.update()
-
-            write_raster_netcdf(
-                output_file,
-                plume.grid,
-                time=day,
-                append=True,
-                attrs={"_version": __version__},
-            )
+        write_raster_netcdf(
+            output_file,
+            plume.grid,
+            time=0.0,
+            append=True,
+            attrs={"_version": __version__},
+        )
 
         out("💥 Finished! 💥")
         out(f"Output written to {output_file}")
@@ -366,9 +356,7 @@ def run(ctx, dry_run: bool) -> None:
 
 
 @plume.command()
-@click.argument(
-    "infile", type=click.Choice(sorted(["ocean.csv", "plume.toml", "river.csv"]))
-)
+@click.argument("infile", type=click.Choice(sorted(["plume.toml"])))
 def generate(infile: str) -> None:
     """Print example input files.
 
@@ -406,7 +394,7 @@ def setup(ctx) -> None:
 
     folder = pathlib.Path(".")
 
-    files = [pathlib.Path(fname) for fname in ["ocean.csv", "plume.toml", "river.csv"]]
+    files = [pathlib.Path(fname) for fname in ["plume.toml"]]
 
     existing_files = [folder / name for name in files if (folder / name).exists()]
     if existing_files:

--- a/tests/test_plume.py
+++ b/tests/test_plume.py
@@ -1,0 +1,26 @@
+import pytest
+from landlab import RasterModelGrid
+
+from plume import Plume
+
+
+def test_plume_deposit_thickness():
+    grid = RasterModelGrid((3, 500), xy_spacing=(100.0, 10000.0))
+
+    plume = Plume(grid)
+
+    assert grid.at_node["sediment_deposit__thickness"] == pytest.approx(0.0)
+
+    plume.run_one_step()
+    actual = grid.at_node["sediment_deposit__thickness"].copy()
+
+    assert not any(actual < 0.0)
+    assert any(actual > 0.0)
+
+    grid.at_node["sediment_deposit__thickness"][:] = 1.0
+
+    plume = Plume(grid)
+    assert grid.at_node["sediment_deposit__thickness"] == pytest.approx(1.0)
+
+    plume.run_one_step()
+    assert grid.at_node["sediment_deposit__thickness"] == pytest.approx(actual + 1.0)


### PR DESCRIPTION
This pull request fixes an issue with adding additional sediment to a grid that already has a *"sediment_deposit__thickness"*. *Plume* had been setting any existing deposit thickness to zero and then adding its own deposit. I've changed things so that now *Plume* will add to any existing sediment deposit and leave it up to the user to clear an existing deposit, if that's what's desired.

Relatedly, I've added a unit test for this behavior and, unrelatedly, I've removed ocean and river time series values from the command line interface (I may add this functionality back in the future but, for now, it was adding unnecessary complexity).