### PR TITLE
Add release actions

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -66,10 +66,10 @@ jobs:
           python setup.py sdist --dist-dir wheelhouse
           twine upload --skip-existing wheelhouse/*.tar.gz
 
-      - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+      # - name: Build wheels
+      #   run: python -m cibuildwheel --output-dir wheelhouse
 
-      - name: Upload distributions
-        run: |
-          twine upload --skip-existing wheelhouse/*.whl
+      # - name: Upload distributions
+      #   run: |
+      #     twine upload --skip-existing wheelhouse/*.whl
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -48,6 +48,8 @@ jobs:
       - name: Install cibuildwheel
         run: |
           conda install pip
+          conda install gsl
+          pip install --upgrade pip wheel setuptools
           python --version
           pip --version
           python -m pip install cibuildwheel==2.3.0 twine

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,73 @@
+name: TestPyPI
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+[ab][0-9]+'
+
+env:
+  TWINE_USERNAME: __token__
+  TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+  TWINE_REPOSITORY_URL: 'https://test.pypi.org/legacy/'
+
+jobs:
+  build-and-publish:
+    name: Build and publish to TestPyPI
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      CIBW_BUILD: 'cp38-* cp39-* cp310-*'
+      CIBW_SKIP: '*-musllinux_*'
+      CIBW_ARCHS_MACOS: "x86_64 arm64"
+      CIBW_ARCHS_LINUX: "auto aarch64"
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge
+          channel-priority: true
+
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Install cibuildwheel
+        run: |
+          conda install pip
+          python --version
+          pip --version
+          python -m pip install cibuildwheel==2.3.0 twine
+
+      - name: Show conda installation info
+        run: |
+          conda info
+          conda list
+
+      - name: Build source distribution
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          pip install numpy
+          python setup.py sdist --dist-dir wheelhouse
+          twine upload --skip-existing wheelhouse/*.tar.gz
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+
+      - name: Upload distributions
+        run: |
+          twine upload --skip-existing wheelhouse/*.whl
+

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Build source distribution
         if: matrix.os == 'ubuntu-latest'
         run: |
-          pip install numpy
+          pip install numpy cython cythongsl
           python setup.py sdist --dist-dir wheelhouse
           twine upload --skip-existing wheelhouse/*.tar.gz
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,9 @@ jobs:
           python setup.py sdist --dist-dir wheelhouse
           twine upload --skip-existing wheelhouse/*.tar.gz
 
-      - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+      # - name: Build wheels
+      #   run: python -m cibuildwheel --output-dir wheelhouse
 
-      - name: Upload distributions
-        run: |
-          twine upload --skip-existing wheelhouse/*.whl
+      # - name: Upload distributions
+      #   run: |
+      #     twine upload --skip-existing wheelhouse/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Build source distribution
         if: matrix.os == 'ubuntu-latest'
         run: |
-          pip install numpy
+          pip install numpy cython cythongsl
           python setup.py sdist --dist-dir wheelhouse
           twine upload --skip-existing wheelhouse/*.tar.gz
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: PyPI
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - '!v[0-9]+.[0-9]+.[0-9]+[ab][0-9]+'
+
+
+env:
+  TWINE_USERNAME: __token__
+  TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+
+jobs:
+  build-and-publish:
+    name: Build and publish to PyPI
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    env:
+      CIBW_BUILD: 'cp38-* cp39-* cp310-*'
+      CIBW_SKIP: '*-musllinux_*'
+      CIBW_ARCHS_MACOS: "x86_64 arm64"
+      CIBW_ARCHS_LINUX: "auto aarch64"
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge
+          channel-priority: true
+
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Install cibuildwheel
+        run: |
+          conda install pip
+          python --version
+          pip --version
+          python -m pip install cibuildwheel==2.3.0 twine
+
+      - name: Show conda installation info
+        run: |
+          conda info
+          conda list
+
+      - name: Build source distribution
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          pip install numpy
+          python setup.py sdist --dist-dir wheelhouse
+          twine upload --skip-existing wheelhouse/*.tar.gz
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+
+      - name: Upload distributions
+        run: |
+          twine upload --skip-existing wheelhouse/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,8 @@ jobs:
       - name: Install cibuildwheel
         run: |
           conda install pip
+          conda install gsl
+          pip install --upgrade pip wheel setuptools
           python --version
           pip --version
           python -m pip install cibuildwheel==2.3.0 twine

--- a/news/8.misc
+++ b/news/8.misc
@@ -1,0 +1,4 @@
+Added GitHub Actions workflows for pushing prereleases to TestPyPI and
+releases to PyPI.
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["cython", "cythongsl", "numpy", "setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "plume"
+name = "sed-plume"
 description = "A hypopycnal sediment-carrying plume entering the ocean."
 authors = [
   {email = "mcflugen@gmail.com"},


### PR DESCRIPTION
This pull request adds two new GitHub Actions workflows. One to push pre-releases to TestPyPI (tags that are version numbers ending with `[ab][0-9]*`), and one to push releases to PyPI (tags that are version numbers without the suffix).

For now, I've only enabled source distributions. There are some issues installing *gsl* for *cibuildwheel* that we'll have to figure out first. It looks like we may have to modify *pyproject.toml* to include something like,
```toml
[tool.cibuildwheel.linux]
before-all = "yum install gsl"
```
and then something similar for *macos* and *windows*.