### PR TITLE
Add Python 3.11 support, drop Python 3.8

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -11,9 +11,9 @@ jobs:
         if:
           github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
           github.repository
-    
+
         runs-on: ubuntu-latest
-        
+
         defaults:
           run:
             shell: bash -l {0}
@@ -23,16 +23,16 @@ jobs:
           - uses: conda-incubator/setup-miniconda@v2
             with:
               auto-update-conda: true
-              python-version: "3.10"
+              python-version: "3.11"
               channels: conda-forge
               channel-priority: true
 
           - name: Show conda installation info
             run: conda info
-    
+
           - name: Install dependencies
             run: |
               pip install -e ".[notebook,testing]"
 
           - name: Test notebooks
-            run: pytest --nbmake notebooks/*ipynb            
+            run: pytest --nbmake notebooks/*ipynb

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     env:
-      CIBW_BUILD: 'cp38-* cp39-* cp310-*'
+      CIBW_BUILD: 'cp39-* cp310-* cp311-*'
       CIBW_SKIP: '*-musllinux_*'
       CIBW_ARCHS_MACOS: "x86_64 arm64"
       CIBW_ARCHS_LINUX: "auto aarch64"
@@ -72,4 +72,3 @@ jobs:
       # - name: Upload distributions
       #   run: |
       #     twine upload --skip-existing wheelhouse/*.whl
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     env:
-      CIBW_BUILD: 'cp38-* cp39-* cp310-*'
+      CIBW_BUILD: 'cp39-* cp310-* cp311-*'
       CIBW_SKIP: '*-musllinux_*'
       CIBW_ARCHS_MACOS: "x86_64 arm64"
       CIBW_ARCHS_LINUX: "auto aarch64"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/news/11.misc
+++ b/news/11.misc
@@ -1,0 +1,2 @@
+
+Added support for Python 3.11, dropped Python 3.8.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,13 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Cython",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Scientific/Engineering :: Physics",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
   "landlab>=2.0.0b7",
   "numpy",


### PR DESCRIPTION
This pull request adds tests for Python 3.11, and drops support for 3.8.